### PR TITLE
Adding kubernetes-helm org

### DIFF
--- a/scripts/repo_groups.sql
+++ b/scripts/repo_groups.sql
@@ -45,7 +45,11 @@ update gha_repos set repo_group = 'Apps' where name in (
   'kubernetes/application-images',
   'kubernetes/examples',
   'kubernetes-incubator/kompose',
-  'kubernetes-incubator/service-catalog'
+  'kubernetes-incubator/service-catalog',
+  'kubernetes-helm/chartmuseum',
+  'kubernetes-helm/monocular',
+  'kubernetes-helm/rudder-federation',
+  'kubernetes-helm/community'
 );
 
 update gha_repos set repo_group = 'Autoscaling and monitoring' where name in (


### PR DESCRIPTION
The [kubernetes-helm](https://github.com/kubernetes-helm) org has a number of Kubernetes projects currently being worked on. This PR attempts to add them to the loop.