### PR TITLE
Updating Apps and Helm for better coverage

### DIFF
--- a/scripts/kubernetes/repo_groups.sql
+++ b/scripts/kubernetes/repo_groups.sql
@@ -40,6 +40,7 @@ update gha_repos set repo_group = 'Clients' where name in (
 
 update gha_repos set repo_group = 'Apps' where name in (
   'kubernetes/kubectl',
+  'kubernetes/helm',
   'kubernetes/charts',
   'kubernetes/application-images',
   'kubernetes/examples',
@@ -140,7 +141,8 @@ update gha_repos set repo_group = 'Docs' where name in (
 update gha_repos set repo_group = 'Helm' where org_login in (
   'kubernetes-helm'
 ) or name in (
-  'kubernetes/helm'
+  'kubernetes/helm',
+  'kubernetes/charts'
 );
 
 update gha_repos set alias = name;


### PR DESCRIPTION
* Charts are coupled to Helm so it's worth grouping them together
  in the Helm Group
* Helm is a sub-set of Apps that we have a particular interest in.
  Adding Helm to the Apps group to have better coverage on that
  space

Note, I'm not entirely sure of the intent of the "Apps" group. What's in there currently covers at least 3 k8s SIGs. If I better understood the meaning of the groups I'd be happy to help add more definition to this area.

Helm is a space, which is a subset of the SIG Apps work, that we have a particular interest in which makes it worth being it's own group.