### PR TITLE
Add git updatation code in ubuntu 16 docs

### DIFF
--- a/INSTALL_UBUNTU16.md
+++ b/INSTALL_UBUNTU16.md
@@ -9,6 +9,11 @@ Prerequisites:
     - `sudo apt-get install golang-1.9-go git psmisc jsonlint yamllint gcc`
     - `sudo ln -s /usr/lib/go-1.9 /usr/lib/go`
     - `mkdir $HOME/data; mkdir $HOME/data/dev`
+- Update git to version 2.11.0 or above :
+    - `sudo add-apt-repository ppa:git-core/ppa -y`
+    - `sudo apt-get update`
+    - `sudo apt-get install git -y`
+    - `git --version`
 1. Configure Go:
     - For example add to `~/.bash_profile` and/or `~/.profile`:
      ```


### PR DESCRIPTION
Fixes #94

The steps are updated after testing on GCP:
  machine type :  n1-standard-8 (8 vCPUs, 30 GB memory) 
  operating-system : Ubuntu 16.04 LTS

The changes are in Prerequisites section : 
  - Update git version 2.11.0 or above 
    which solves the error during failure of executing command  with script ./shared/reinit.sh.

I (Amrish) and my friend(vharsh) have discussed it in slack.

```
vharsh [4:28 AM]
Thanks Łukasz.
I am slightly confused with `./git/git_tags.sh` which is executed by `annotations.go`

The command doesn't work on my machine, `Ubuntu16.04`. 
This fails with an error which says,
```fatal: unknown date format unix```

I am stretching my imagination but is the `unix` in `creatordate` some sort of bash function or something to do with `fnmatch` ?
I read about it from https://explainshell.com/explain?cmd=git+tag+-l+--format%3D%22%25%28creatordate%3Aunix%29%22
```git tag -l --format="%(creatordate:unix)"```
In that case is `creatordate:unix` something which is only present in some machines ? (edited)

lukaszgryglicki [10:48 AM]
unix means date formatted as unix timestamp.
This is the numbe rof seconds since epoch 1970-01-01 00:00:00
Example
2018-04-06 13:16:01 root@cncftest:~/dev/go/src/devstats# git tag -l --format=“%(creatordate:unix)”
1517253128
1517253128
1517323837
1517411098
1518783408
1521618336
what is You git version?
*your
Mine is: git --version
git version 2.11.0

vharsh [10:54 AM]
Okay, I seem to have an older version of `git` Mine is `git version 2.7.4`

lukaszgryglicki [10:55 AM]
you should do man git-tags

vharsh [10:55 AM]
This is what I get without specifying the date format.
```harsh@athena:~/code/go/src/devstats$ git tag -l --format="%(creatordate)"
Mon Jan 29 19:12:08 2018 +0000
Tue Jan 30 14:50:37 2018 +0000
Wed Jan 31 15:04:58 2018 +0000
Fri Feb 16 13:16:48 2018 +0100
Wed Mar 21 07:45:36 2018 +0000```

lukaszgryglicki [10:56 AM]
and search for something similar, I believe that unix timestamp format should be supported, but maybe is named differently
I’ve used unix timestamp format because it is easiest to parse - this is just a number of seconds
or maybe just upgrade git

Amrish [12:13 PM]
by upgrading git , issue is resolved, thanks @lukaszgryglicki

lukaszgryglicki [12:13 PM]
no problem
``` 