### PR TITLE
Rename kargo to kubespray

### DIFF
--- a/scripts/kubernetes/repo_groups.sql
+++ b/scripts/kubernetes/repo_groups.sql
@@ -96,6 +96,7 @@ update gha_repos set repo_group = 'Node' where name in (
 
 update gha_repos set repo_group = 'Cluster lifecycle' where name in (
   'kubernetes-incubator/kargo',
+  'kubernetes-incubator/kubespray',
   'kubernetes-incubator/kube-aws',
   'kubernetes-incubator/kube-mesos-framework',
   'kubernetes/kops',


### PR DESCRIPTION
Kargo have been renamed to kubespray. 
As I don't know how history is working I created a new entry instead of renaming it.
Let me know how it should be done.

