### PR TITLE
update Gopkg to include indirect dependencies

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,96 +2,108 @@
 
 
 [[projects]]
+  digest = "1:891a3ba57368b85b1b7d531c33458c9b4bffea5319684f2cddb05e96795ecb4f"
+  name = "github.com/cncf/devstatscode"
+  packages = [
+    ".",
+    "test",
+  ]
+  pruneopts = "UT"
+  revision = "1797f0b35239e0ad36dcdbb42aa0e1d17d010029"
+  version = "v0.7.0"
+
+[[projects]]
+  digest = "1:97df918963298c287643883209a2c3f642e6593379f97ab400c2a2e219ab647d"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
+  pruneopts = "UT"
   revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
   version = "v1.2.0"
 
 [[projects]]
+  digest = "1:f4f203acd8b11b8747bdcd91696a01dbc95ccb9e2ca2db6abf81c3a4f5e950ce"
   name = "github.com/google/go-github"
   packages = ["github"]
+  pruneopts = "UT"
   revision = "f55b50f38167644bb7e4be03d9a2bde71d435239"
   version = "v18.2.0"
 
 [[projects]]
+  digest = "1:a63cff6b5d8b95638bfe300385d93b2a6d9d687734b863da8e09dc834510a690"
   name = "github.com/google/go-querystring"
   packages = ["query"]
+  pruneopts = "UT"
   revision = "44c6ddd0a2342c386950e880b658017258da92fc"
   version = "v1.0.0"
 
 [[projects]]
-  name = "github.com/gorilla/context"
-  packages = ["."]
-  revision = "08b5f424b9271eedf6f9f0ce86cb9396ed337a42"
-  version = "v1.1.1"
-
-[[projects]]
-  name = "github.com/gorilla/mux"
-  packages = ["."]
-  revision = "e3702bed27f0d39777b0b37b664b6280e8ef8fbf"
-  version = "v1.6.2"
-
-[[projects]]
+  digest = "1:8ef506fc2bb9ced9b151dafa592d4046063d744c646c1bbe801982ce87e4bc24"
   name = "github.com/lib/pq"
   packages = [
     ".",
-    "oid"
+    "oid",
   ]
+  pruneopts = "UT"
   revision = "4ded0e9383f75c197b3a2aaa6d590ac52df6fd79"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:aa3d8d42865c42626b5c1add193692d045b3188b1479f0a0a88690d21fe20083"
   name = "github.com/mailru/easyjson"
   packages = [
     ".",
     "buffer",
     "jlexer",
-    "jwriter"
+    "jwriter",
   ]
+  pruneopts = "UT"
   revision = "60711f1a8329503b04e1c88535f419d0bb440bff"
 
 [[projects]]
-  name = "github.com/mattn/go-sqlite3"
-  packages = ["."]
-  revision = "c7c4067b79cc51e6dfdcef5c702e74b1e0fa7c75"
-  version = "v1.10.0"
-
-[[projects]]
+  digest = "1:3371d8e907e3456fd56105ba454a63b8dc5537481929588162b3a7f78d5b64af"
   name = "github.com/olivere/elastic"
   packages = [
     ".",
     "config",
-    "uritemplates"
+    "uritemplates",
   ]
+  pruneopts = "UT"
   revision = "4982266e48e0dc5c639e389b50221dcef09cdc99"
   version = "v6.2.12"
 
 [[projects]]
+  digest = "1:40e195917a951a8bf867cd05de2a46aaf1806c50cf92eebf4c16f78cd196f747"
   name = "github.com/pkg/errors"
   packages = ["."]
+  pruneopts = "UT"
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:d6b719875cf8091fbab38527d81d34e71f4521b9ee9ccfbd4a32cff2ac5af96e"
   name = "golang.org/x/net"
   packages = [
     "context",
-    "context/ctxhttp"
+    "context/ctxhttp",
   ]
+  pruneopts = "UT"
   revision = "04ba8c85dd55b4ee6099abbb0a90760b080c24a4"
 
 [[projects]]
   branch = "master"
+  digest = "1:bd33fb266abe5db1fb1c04e58e98192068f05a8d22fae2a9f22270c8422bb331"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
-    "internal"
+    "internal",
   ]
+  pruneopts = "UT"
   revision = "f42d05182288abf10faef86d16c0d07b8d40ea2d"
 
 [[projects]]
+  digest = "1:8029e9743749d4be5bc9f7d42ea1659471767860f0cdc34d37c3111bd308a295"
   name = "golang.org/x/text"
   packages = [
     "internal/gen",
@@ -99,12 +111,14 @@
     "internal/ucd",
     "transform",
     "unicode/cldr",
-    "unicode/norm"
+    "unicode/norm",
   ]
+  pruneopts = "UT"
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
+  digest = "1:08206298775e5b462e6c0333f4471b44e63f1a70e42952b6ede4ecc9572281eb"
   name = "google.golang.org/appengine"
   packages = [
     "internal",
@@ -113,20 +127,27 @@
     "internal/log",
     "internal/remote_api",
     "internal/urlfetch",
-    "urlfetch"
+    "urlfetch",
   ]
+  pruneopts = "UT"
   revision = "4a4468ece617fc8205e99368fa2200e9d1fad421"
   version = "v1.3.0"
 
 [[projects]]
+  digest = "1:342378ac4dcb378a5448dd723f0784ae519383532f5e70ade24132c4c8693202"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
+  pruneopts = "UT"
   revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
   version = "v2.2.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "9fa377643d38d682cee23fb8571b9022d286dbbebd0d7cb6a3db3c65b5f4cec9"
+  input-imports = [
+    "github.com/cncf/devstatscode",
+    "github.com/cncf/devstatscode/test",
+    "gopkg.in/yaml.v2",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -25,31 +25,31 @@
 #   unused-packages = true
 
 
-[[constraint]]
+[[override]]
   name = "github.com/google/go-github"
   version = "18.2.0"
 
-[[constraint]]
+[[override]]
   name = "github.com/gorilla/mux"
   version = "1.6.2"
 
-[[constraint]]
+[[override]]
   name = "github.com/lib/pq"
   version = "1.0.0"
 
-[[constraint]]
+[[override]]
   name = "github.com/mattn/go-sqlite3"
   version = "1.10.0"
 
-[[constraint]]
+[[override]]
   name = "github.com/olivere/elastic"
   version = "6.2.12"
 
-[[constraint]]
+[[override]]
   branch = "master"
   name = "golang.org/x/oauth2"
 
-[[constraint]]
+[[override]]
   name = "golang.org/x/text"
   version = "0.3.0"
 
@@ -61,22 +61,22 @@
   go-tests = true
   unused-packages = true
 
-[[constraint]]
+[[override]]
   name = "github.com/jgautheron/goconst"
   version = "1.1.0"
 
-[[constraint]]
+[[override]]
   branch = "master"
   name = "github.com/jgautheron/usedexports"
 
-[[constraint]]
+[[override]]
   name = "github.com/kisielk/errcheck"
   version = "1.1.0"
 
-[[constraint]]
+[[override]]
   branch = "master"
   name = "golang.org/x/lint"
 
-[[constraint]]
+[[override]]
   branch = "master"
   name = "golang.org/x/tools"


### PR DESCRIPTION
I'm doing this to avoid the following error message when running `dep ensure`:

```
$ dep ensure
Warning: the following project(s) have [[constraint]] stanzas in Gopkg.toml:

  ✗  github.com/google/go-github
  ✗  github.com/gorilla/mux
  ✗  github.com/jgautheron/goconst
  ✗  github.com/jgautheron/usedexports
  ✗  github.com/kisielk/errcheck
  ✗  github.com/lib/pq
  ✗  github.com/mattn/go-sqlite3
  ✗  github.com/olivere/elastic
  ✗  golang.org/x/lint
  ✗  golang.org/x/oauth2
  ✗  golang.org/x/text
  ✗  golang.org/x/tools

However, these projects are not direct dependencies of the current project:
they are not imported in any .go files, nor are they in the 'required' list in
Gopkg.toml. Dep only applies [[constraint]] rules to direct dependencies, so
these rules will have no effect.

Either import/require packages from these projects so that they become direct
dependencies, or convert each [[constraint]] to an [[override]] to enforce rules
on these projects, if they happen to be transitive dependencies.
```

Please let me know if there's a reason why you're not explicitly enforcing these dependencies.