### PR TITLE
repo was renamed to cluster-addons

### DIFF
--- a/scripts/kubernetes/repo_groups.sql
+++ b/scripts/kubernetes/repo_groups.sql
@@ -118,7 +118,7 @@ update gha_repos set repo_group = 'SIG Cluster Lifecycle' where name in (
   'kubernetes-incubator/bootkube',
   'kubernetes-incubator/kube-aws',
   'kubernetes-incubator/kubespray',
-  'kubernetes-sigs/addon-operators',
+  'kubernetes-sigs/cluster-addons',
   'kubernetes-sigs/cluster-api',
   'kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm',
   'kubernetes-sigs/cluster-api-provider-aws',


### PR DESCRIPTION
The Cluster Addons subproject decided to use the name `cluster-addons` across Slack, Github, etc consistently, cf https://github.com/kubernetes/org/issues/1583