### PR TITLE
Add cisco acquisitions to companies.yaml

### DIFF
--- a/companies.yaml
+++ b/companies.yaml
@@ -20,4 +20,5 @@ acquisitions:
   - ['(?i)^loodse$', 'Kubermatic GmbH']
   - ['(?i)^rancher\s*labs(\s+inc\.?)?$', 'SUSE LLC']
   - ['(?i)^(packet\s*host(\s+inc\.?)?|equinix\s*metal)$', 'Equinix Inc.']
+  - ['(?i)^(appdynamics(\s+(llc|\(cisco\)))?|epsagon(\s+(llc)?)|banzai\s?cloud(\s+zrt)?)$', 'Cisco']
 #  - ['(?i)^red\s*hat(\s+inc\.?)?$', IBM]


### PR DESCRIPTION
Hi there,

we would like to accomplish the following mapping for some of Cisco's subsidiaries:
```
AppDynamics LLC -> Cisco
AppDynamics (Cisco) -> Cisco
Epsagon -> Cisco
Banzai Cloud Zrt -> Cisco
```
From existing closed issues we assumed that updating the companies.yaml would be the right approach to achieve this. 

Thanks,

CC: @justaugustus