### PR TITLE
Update mastercard company mappings

### DIFF
--- a/companies.yaml
+++ b/companies.yaml
@@ -21,4 +21,5 @@ acquisitions:
   - ['(?i)^rancher\s*labs(\s+inc\.?)?$', 'SUSE LLC']
   - ['(?i)^(packet\s*host(\s+inc\.?)?|equinix\s*metal)$', 'Equinix Inc.']
   - ['(?i)^(appdynamics(\s+(llc|\(cisco\)))?|epsagon(\s+(llc))?|banzai\s*?cloud(\s+zrt)?)$', 'Cisco']
+  - ['(?i)^(apt|applied\s*predictive(\s*technologies)?|ciphertrace|sessionm|dynamic\s*yield|5one(\s*marketing)?(\s*limited)?|mastercard(\s*\S*)?(,?\s*inc\.?)?)$', 'Mastercard International Incorporated']
 #  - ['(?i)^red\s*hat(\s+inc\.?)?$', IBM]

--- a/companies.yaml
+++ b/companies.yaml
@@ -21,5 +21,5 @@ acquisitions:
   - ['(?i)^rancher\s*labs(\s+inc\.?)?$', 'SUSE LLC']
   - ['(?i)^(packet\s*host(\s+inc\.?)?|equinix\s*metal)$', 'Equinix Inc.']
   - ['(?i)^(appdynamics(\s+(llc|\(cisco\)))?|epsagon(\s+(llc))?|banzai\s*?cloud(\s+zrt)?)$', 'Cisco']
-  - ['(?i)^(apt|applied\s*predictive(\s*technologies)?|ciphertrace|sessionm|dynamic\s*yield|5one(\s*marketing)?(\s*limited)?|mastercard(\s*\S*)?(,?\s*inc\.?)?)$', 'Mastercard International Incorporated']
+  - ['(?i)^(apt|applied\s*predictive(\s*technologies)?|sessionm|mastercard(\s*\S*)?)(,?\s*inc\.?)?$', 'Mastercard International Incorporated']
 #  - ['(?i)^red\s*hat(\s+inc\.?)?$', IBM]


### PR DESCRIPTION

Add matches for two Mastercard acquisitions:
- apt / applied predictive / applied predictive technologies 
- sessionm / sessionm inc

Adds match for Mastercard business units for example Mastercard D&S, Mastercard O&T, Mastercard L&E, etc

