### PR TITLE
Update link to list of maintainers

### DIFF
--- a/ADDING_NEW_PROJECT.md
+++ b/ADDING_NEW_PROJECT.md
@@ -58,7 +58,7 @@ This file describes how to add new project on the test and production servers.
 - Final deploy script is: `./devel/deploy_all.sh`. It should do all deployment automatically on the prod server. Follow all code from this script (eventually run some parts manually, the final version should do full deploy OOTB).
 - If added disabled project, remember to add it to `crontab -e` via `GHA2DB_PROJECTS_OVERRIDE="+new_disabled_project"`.
 - Also add in other devstats repositories, follow `cncf/devstats-helm:ADDING_NEW_PROJECTS.md`.
-- Update cncf/gitdm affiliations with [official project maintainers](https://docs.google.com/spreadsheets/d/1Pr8cyp8RLrNGx9WBAgQvBzUUmqyOv69R7QAFKhacJEM/edit#gid=262035321).
+- Update cncf/gitdm affiliations with [official project maintainers](http://maintainers.cncf.io/).
 
 ## Update shared Grafana data
 


### PR DESCRIPTION
The Google Sheet is deprecated, the canonical link to the maintainers list is http://maintainers.cncf.io/ now.



Signed-off-by: Matthias Rampke <matthias@prometheus.io>

Please make sure that you follow instructions from [CONTRIBUTING](https://github.com/cncf/devstats/blob/master/CONTRIBUTING.md)

Specially:
- Check if all tests pass, see [TESTING](https://github.com/cncf/devstats/blob/master/TESTING.md) for deatils.
- Make sure you've added test coverage for new features/metrics.
- Make sure you have updated documentation.
- If you added a new metric, please make sure you have been following instructions about [adding new metric](https://github.com/cncf/devstats/blob/master/METRICS.md).
